### PR TITLE
Fix a ranlib warning that librocket's precompiled.cpp is empty

### DIFF
--- a/Source/Core/precompiled.cpp
+++ b/Source/Core/precompiled.cpp
@@ -27,3 +27,6 @@
 
 #include "precompiled.h"
 
+// XCode's ranlib complain on empty object, adding any function prevents this
+void RocketDummyFunction() {
+}


### PR DESCRIPTION
PTAL